### PR TITLE
Fix presentation.holder instead of issuer

### DIFF
--- a/src/types/presentation.ts
+++ b/src/types/presentation.ts
@@ -2,7 +2,7 @@ import type { Credential, Proof, Issuer } from './credential.js';
 
 export interface VerifiablePresentation {
   readonly '@context': string[];
-  readonly issuer: Issuer;
+  readonly holder: Issuer;
   readonly type: string;
   readonly verifiableCredential: Credential | Credential[];
   readonly proof: Proof;

--- a/test/Verify.presentation.spec.ts
+++ b/test/Verify.presentation.spec.ts
@@ -131,6 +131,7 @@ describe('Verify.verifyPresentation', () => {
       const verifiableCredential = [v2WithStatus]
       const presentation = await getSignedVP({ holder, verifiableCredential }) as VerifiablePresentation
       const credentialResults = [expectedV2WithStatusResult]
+      expect(presentation.holder).to.equal(holder)
       const expectedPresentationResult = getExpectedVerifiedPresentationResult({ credentialResults })
       const result = await verifyPresentation({ presentation, knownDIDRegistries })
       result.credentialResults?.forEach(credResult => delete credResult.additionalInformation)


### PR DESCRIPTION
https://www.w3.org/TR/vc-data-model-1.1/#presentations-0
and
https://www.w3.org/TR/vc-data-model-2.0/#verifiable-presentations
use the `holder` property to represent the signer of the presentation rather than the `issuer` property used for credentials.